### PR TITLE
feat(entries): Add the ability to list user's entries

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     noko_cli (0.1.1)
       faraday (~> 2.3.0)
+      tty-table (~> 0.12.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,6 +20,8 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    pastel (0.8.0)
+      tty-color (~> 0.5)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -60,7 +63,19 @@ GEM
       rubocop (~> 1.31)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    strings (0.2.1)
+      strings-ansi (~> 0.2)
+      unicode-display_width (>= 1.5, < 3.0)
+      unicode_utils (~> 1.4)
+    strings-ansi (0.2.0)
+    tty-color (0.6.0)
+    tty-screen (0.8.1)
+    tty-table (0.12.0)
+      pastel (~> 0.8)
+      strings (~> 0.2.0)
+      tty-screen (~> 0.8)
     unicode-display_width (2.2.0)
+    unicode_utils (1.4.0)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,26 @@ PATH
   remote: .
   specs:
     noko_cli (0.1.1)
+      faraday (~> 2.3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    coderay (1.1.3)
     diff-lcs (1.5.0)
+    faraday (2.3.0)
+      faraday-net_http (~> 2.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (2.0.3)
     json (2.6.2)
+    method_source (1.0.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.5.0)
@@ -49,6 +59,7 @@ GEM
     rubocop-rspec (2.12.1)
       rubocop (~> 1.31)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     unicode-display_width (2.2.0)
 
 PLATFORMS
@@ -56,6 +67,7 @@ PLATFORMS
 
 DEPENDENCIES
   noko_cli!
+  pry (~> 0.14.1)
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.31.1)

--- a/bin/console
+++ b/bin/console
@@ -11,5 +11,10 @@ require "noko_cli"
 # require "pry"
 # Pry.start
 
+# Examples
+
+# Entries
+# NokoCli::Entries.new.list
+
 require "irb"
 IRB.start(__FILE__)

--- a/exe/noko_cli
+++ b/exe/noko_cli
@@ -2,3 +2,5 @@
 # frozen_string_literal: true
 
 require "noko_cli"
+
+NokoCli::Entries.new.list

--- a/lib/noko_cli.rb
+++ b/lib/noko_cli.rb
@@ -3,6 +3,5 @@
 require_relative "noko_cli/version"
 
 module NokoCli
-  class Error < StandardError; end
-  # Your code goes here...
+  autoload :Entries, "noko_cli/entries"
 end

--- a/lib/noko_cli/entries.rb
+++ b/lib/noko_cli/entries.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "faraday"
+require "tty-table"
 
 module NokoCli
   # This is an entry resource, which could be listed
@@ -14,8 +15,10 @@ module NokoCli
     end
 
     def list
-      conn.get("current_user/entries").body
+      puts TTY::Table.new(headers, rows).render(:ascii, resize: true)
     end
+
+    private
 
     def conn
       @conn ||= Faraday.new({ url: BASE_URL, params: { noko_token: NOKO_TOKEN } }) do |f|
@@ -25,6 +28,22 @@ module NokoCli
         end
         f.adapter @adapter, @stubs
       end
+    end
+
+    def current_user_entries
+      conn.get("current_user/entries").body
+    end
+
+    def headers
+      %w[date minutes description]
+    end
+
+    def rows
+      current_user_entries.map { |entry| row(entry) }
+    end
+
+    def row(entry)
+      [entry["date"], entry["minutes"], entry["description"]]
     end
   end
 end

--- a/lib/noko_cli/entries.rb
+++ b/lib/noko_cli/entries.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+module NokoCli
+  # This is an entry resource, which could be listed
+  class Entries
+    BASE_URL = "https://api.nokotime.com/v2"
+    NOKO_TOKEN = ENV.fetch("NOKO_TOKEN", nil)
+
+    def initialize(adapter: Faraday.default_adapter, stubs: nil)
+      @adapter = adapter
+      @stubs = stubs
+    end
+
+    def list
+      conn.get("current_user/entries").body
+    end
+
+    def conn
+      @conn ||= Faraday.new({ url: BASE_URL, params: { noko_token: NOKO_TOKEN } }) do |f|
+        unless @stubs
+          f.request :json
+          f.response :json, content_type: "application/json"
+        end
+        f.adapter @adapter, @stubs
+      end
+    end
+  end
+end

--- a/noko_cli.gemspec
+++ b/noko_cli.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.metadata = { "rubygems_mfa_required" => "true" }
 
   spec.add_dependency "faraday", "~> 2.3.0"
+  spec.add_dependency "tty-table", "~> 0.12.0"
 
   spec.add_development_dependency "pry", "~> 0.14.1"
 

--- a/noko_cli.gemspec
+++ b/noko_cli.gemspec
@@ -32,8 +32,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.metadata = { "rubygems_mfa_required" => "true" }
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "faraday", "~> 2.3.0"
+
+  spec.add_development_dependency "pry", "~> 0.14.1"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/spec/fixtures/entries/list.json
+++ b/spec/fixtures/entries/list.json
@@ -45,5 +45,59 @@
     "invoiced_outside_of_noko_url": "https://api.nokotime.com/v2/entries/31712559/marked_as_invoiced",
     "approved_url": "https://api.nokotime.com/v2/entries/31712559/approved",
     "unapproved_url": "https://api.nokotime.com/v2/entries/31712559/unapproved"
+  },
+  {
+    "id": 31728366,
+    "date": "2022-07-05",
+    "billable": true,
+    "minutes": 90,
+    "description": "Rendering the entry #development #testing",
+    "created_at": "2022-07-05T21:50:56Z",
+    "updated_at": "2022-07-05T21:57:39Z",
+    "approved_at": "",
+    "source_url": "",
+    "user": {
+      "id": 80271,
+      "email": "juan@ombulabs.com",
+      "first_name": "Juan",
+      "last_name": "Vasquez",
+      "profile_image_url": "https://usercontent.nokoti.me/public_uploads/avatar/b4262edf3e3a5ff4aa80ccf58d455c8666f47df0/88f6c1eb3e4f94255deac05154922dfe.jpg",
+      "url": "https://api.nokotime.com/v2/users/80271"
+    },
+    "approved_by": "",
+    "tags": [
+      {
+        "id": 1443510,
+        "name": "development",
+        "billable": true,
+        "formatted_name": "#development",
+        "url": "https://api.nokotime.com/v2/tags/1443510"
+      },
+      {
+        "id": 1443512,
+        "name": "testing",
+        "billable": true,
+        "formatted_name": "#testing",
+        "url": "https://api.nokotime.com/v2/tags/1443512"
+      }
+    ],
+    "project": {
+      "id": 657042,
+      "name": "noko_cli",
+      "billing_increment": 15,
+      "enabled": true,
+      "billable": true,
+      "color": "#55c9ef",
+      "url": "https://api.nokotime.com/v2/projects/657042"
+    },
+    "invoiced": "",
+    "invoiced_at": "",
+    "invoice": "",
+    "import": "",
+    "url": "https://api.nokotime.com/v2/entries/31728366",
+    "invoiced_outside_of_freckle_url": "https://api.nokotime.com/v2/entries/31728366/invoiced_outside_of_freckle",
+    "invoiced_outside_of_noko_url": "https://api.nokotime.com/v2/entries/31728366/marked_as_invoiced",
+    "approved_url": "https://api.nokotime.com/v2/entries/31728366/approved",
+    "unapproved_url": "https://api.nokotime.com/v2/entries/31728366/unapproved"
   }
 ]

--- a/spec/fixtures/entries/list.json
+++ b/spec/fixtures/entries/list.json
@@ -1,0 +1,49 @@
+[
+  {
+    "id": 31712559,
+    "date": "2022-07-03",
+    "billable": true,
+    "minutes": 60,
+    "description": "#development implementing list functionality, installing faraday",
+    "created_at": "2022-07-03T20:55:05Z",
+    "updated_at": "2022-07-03T20:55:05Z",
+    "approved_at": "",
+    "source_url": "",
+    "user": {
+      "id": 80271,
+      "email": "juan@ombulabs.com",
+      "first_name": "Juan",
+      "last_name": "Vasquez",
+      "profile_image_url": "https://usercontent.nokoti.me/public_uploads/avatar/b4262edf3e3a5ff4aa80ccf58d455c8666f47df0/88f6c1eb3e4f94255deac05154922dfe.jpg",
+      "url": "https://api.nokotime.com/v2/users/80271"
+    },
+    "approved_by": "",
+    "tags": [
+      {
+        "id": 1443510,
+        "name": "development",
+        "billable": true,
+        "formatted_name": "#development",
+        "url": "https://api.nokotime.com/v2/tags/1443510"
+      }
+    ],
+    "project": {
+      "id": 657042,
+      "name": "noko_cli",
+      "billing_increment": 15,
+      "enabled": true,
+      "billable": true,
+      "color": "#55c9ef",
+      "url": "https://api.nokotime.com/v2/projects/657042"
+    },
+    "invoiced": "",
+    "invoiced_at": "",
+    "invoice": "",
+    "import": "",
+    "url": "https://api.nokotime.com/v2/entries/31712559",
+    "invoiced_outside_of_freckle_url": "https://api.nokotime.com/v2/entries/31712559/invoiced_outside_of_freckle",
+    "invoiced_outside_of_noko_url": "https://api.nokotime.com/v2/entries/31712559/marked_as_invoiced",
+    "approved_url": "https://api.nokotime.com/v2/entries/31712559/approved",
+    "unapproved_url": "https://api.nokotime.com/v2/entries/31712559/unapproved"
+  }
+]

--- a/spec/noko_cli/entries_spec.rb
+++ b/spec/noko_cli/entries_spec.rb
@@ -10,24 +10,22 @@ RSpec.describe NokoCli::Entries do
     end
     let(:entries) { described_class.new(adapter: :test, stubs: stubs) }
 
-    xit "returns an array of entries" do
-      expect(entries.list).to be_instance_of Array
+    it "includes headers" do
+      expect do
+        entries.list
+      end.to output(/date |minutes |description/).to_stdout
     end
 
-    xit "includes one entry" do
-      expect(entries.list.count).to eq 1
+    it "includes first entry info" do
+      expect do
+        entries.list
+      end.to output(/2022-07-03 |60 |#development implementing list functionality, installing faraday/).to_stdout
     end
-  end
 
-  def stub_response(fixture:, status: 200, headers: { "Content-Type" => "application/json" })
-    [status, headers, JSON.parse(File.read("spec/fixtures/#{fixture}.json"))]
-  end
-
-  def stub_request(path, response:, method: :get, body: {})
-    Faraday::Adapter::Test::Stubs.new do |stub|
-      arguments = [method, "/v2/#{path}"]
-      arguments << body.to_json if %i[post put patch].include?(method)
-      stub.send(*arguments) { |_env| response }
+    it "includes second entry info" do
+      expect do
+        entries.list
+      end.to output(/2022-07-05 |90 |Rendering the entry #development #testing/).to_stdout
     end
   end
 end

--- a/spec/noko_cli/entries_spec.rb
+++ b/spec/noko_cli/entries_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+
+RSpec.describe NokoCli::Entries do
+  describe "#list" do
+    let(:stubs) do
+      stub_request("current_user/entries", response: stub_response(fixture: "entries/list"))
+    end
+    let(:entries) { described_class.new(adapter: :test, stubs: stubs) }
+
+    it "returns an array of entries" do
+      expect(entries.list).to be_instance_of Array
+    end
+
+    it "includes one entry" do
+      expect(entries.list.count).to eq 1
+    end
+  end
+
+  def stub_response(fixture:, status: 200, headers: { "Content-Type" => "application/json" })
+    [status, headers, JSON.parse(File.read("spec/fixtures/#{fixture}.json"))]
+  end
+
+  def stub_request(path, response:, method: :get, body: {})
+    Faraday::Adapter::Test::Stubs.new do |stub|
+      arguments = [method, "/v2/#{path}"]
+      arguments << body.to_json if %i[post put patch].include?(method)
+      stub.send(*arguments) { |_env| response }
+    end
+  end
+end

--- a/spec/noko_cli/entries_spec.rb
+++ b/spec/noko_cli/entries_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe NokoCli::Entries do
     end
     let(:entries) { described_class.new(adapter: :test, stubs: stubs) }
 
-    it "returns an array of entries" do
+    xit "returns an array of entries" do
       expect(entries.list).to be_instance_of Array
     end
 
-    it "includes one entry" do
+    xit "includes one entry" do
       expect(entries.list.count).to eq 1
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,15 @@
 
 require "noko_cli"
 
+# Had an issue with $stdout.ioctl
+# https://github.com/rspec/rspec-expectations/issues/1305#issuecomment-876868287
+require "stringio"
+class StringIO
+  def ioctl(*)
+    0
+  end
+end
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -11,5 +20,17 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+end
+
+def stub_response(fixture:, status: 200, headers: { "Content-Type" => "application/json" })
+  [status, headers, JSON.parse(File.read("spec/fixtures/#{fixture}.json"))]
+end
+
+def stub_request(path, response:, method: :get, body: {})
+  Faraday::Adapter::Test::Stubs.new do |stub|
+    arguments = [method, "/v2/#{path}"]
+    arguments << body.to_json if %i[post put patch].include?(method)
+    stub.send(*arguments) { |_env| response }
   end
 end


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
- [x] Using a noko personal token, we can access to the account
  information, and list the user's entries.
- [x] Install and configure faraday
- [x] Install pry for debugging

Closes #3
END_COMMIT_OVERRIDE
